### PR TITLE
Switch to hyper for http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/gifnksm/oauth-client-rs"
 version = "0.1.4"
 
 [dependencies]
-curl = "0.3.1"
+hyper = "0.9.10"
 log = "0.3"
 rand = "0.3"
 rust-crypto = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 
 //! OAuth 1.0 client library for Rust.
 //!
-//! Dependent on libcurl.
+//! Dependent on hyper.
 //!
 //! [Repository](https://github.com/charlag/oauth-client-rs)
 //!
@@ -30,7 +30,7 @@
 #![warn(unused_results)]
 
 extern crate crypto;
-extern crate curl;
+extern crate hyper;
 #[macro_use]
 extern crate log;
 extern crate rand;
@@ -47,23 +47,28 @@ use rustc_serialize::base64::{self, ToBase64};
 use crypto::hmac::Hmac;
 use crypto::mac::{Mac, MacResult};
 use crypto::sha1::Sha1;
-use curl::easy::{Easy, List};
+use hyper::Client;
+use hyper::status::StatusCode;
+use hyper::header::{Headers,Authorization};
 use url::form_urlencoded;
 
 /// The `Error` type
 #[derive(Debug)]
 pub enum Error {
-    /// Curl error
-    Curl(curl::Error),
+    /// Hyper error
+    Hyper(hyper::Error),
     /// Http status
-    HttpStatus(u32),
+    HttpStatus(StatusCode),
+    /// Std IO error
+    IO(std::io::Error),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Curl(ref err) => write!(f, "Curl error: {}", err),
+            Error::Hyper(ref err) => write!(f, "Hyper error: {}", err),
             Error::HttpStatus(ref resp) => write!(f, "HTTP status error: {}", resp),
+            Error::IO(ref err) => write!(f, "IO error: {}",err),
         }
     }
 }
@@ -71,22 +76,30 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::Curl(ref err) => err.description(),
+            Error::Hyper(ref err) => err.description(),
             Error::HttpStatus(_) => "HTTP status error",
+            Error::IO(ref err) => err.description(),
         }
     }
 
     fn cause(&self) -> Option<&error::Error> {
         match *self {
-            Error::Curl(ref err) => Some(err),
+            Error::Hyper(ref err) => Some(err),
             Error::HttpStatus(_) => None,
+            Error::IO(ref err) => Some(err),
         }
     }
 }
 
-impl From<curl::Error> for Error {
-    fn from(err: curl::Error) -> Error {
-        Error::Curl(err)
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error {
+        Error::IO(err)
+    }
+}
+
+impl From<hyper::Error> for Error {
+    fn from(err: hyper::Error) -> Error {
+        Error::Hyper(err)
     }
 }
 
@@ -232,7 +245,7 @@ fn get_header(method: &str,
 /// # Examples
 ///
 /// ```
-/// # extern crate curl;
+/// # extern crate hyper;
 /// # extern crate oauth_client;
 /// # fn main() {
 /// const REQUEST_TOKEN: &'static str = "http://oauthbin.com/v1/request-token";
@@ -271,25 +284,19 @@ pub fn get(uri: &str,
     } else {
         format!("{}", uri)
     };
-    let mut handle = Easy::new();
-    let mut list = List::new();
-    list.append(format!("Authorization: {}", header).as_ref()).unwrap();
+    let mut handle = Client::new();
+    let mut headers = Headers::new();
+    headers.set(
+        Authorization(
+            header  
+        )
+    );
+    let mut response = try!(handle.get(req_uri.as_str()).headers(headers).send());
+    if response.status != StatusCode::Ok {
+        return Err(Error::HttpStatus(response.status));
+    }
     let mut resp = Vec::new();
-    try!(handle.url(req_uri.as_ref()));
-    try!(handle.http_headers(list));
-    try!(handle.get(true));
-    {
-        let mut transfer = handle.transfer();
-        try!(transfer.write_function(|data| {
-            resp.extend_from_slice(data);
-            Ok(data.len())
-        }));
-        try!(transfer.perform());
-    }
-    let code = try!(handle.response_code());
-    if code != 200 {
-        return Err(Error::HttpStatus(code));
-    }
+    try!(std::io::copy(&mut response, &mut resp));
     Ok(resp)
 }
 
@@ -310,32 +317,22 @@ pub fn post(uri: &str,
             token: Option<&Token>,
             other_param: Option<&ParamList>)
             -> Result<Vec<u8>, Error> {
-    let (header, body) = get_header("POST", uri, consumer, token, other_param);
-    let mut handle = Easy::new();
-    let mut list = List::new();
-    list.append(format!("Authorization: {}", header).as_ref()).unwrap();
+    let (header, mut body) = get_header("POST", uri, consumer, token, other_param);
+    let mut handle = Client::new();
+    let mut headers = Headers::new();
+    headers.set(
+        Authorization(
+            header  
+        )
+    );
+    let mut response = try!(handle.post(uri).body(&mut std::io::Cursor::new(body.as_str())).headers(headers).send());
+    if response.status != StatusCode::Ok {
+        return Err(Error::HttpStatus(response.status));
+    }
     let mut resp = Vec::new();
-    try!(handle.url(uri.as_ref()));
-    try!(handle.http_headers(list));
-    try!(handle.post(true));
-    try!(handle.post_field_size(body.len() as u64));
-    {
-        let mut transfer = handle.transfer();
-        try!(transfer.read_function(|into| {
-            let mut body = body.as_bytes();
-            Ok(body.read(into).unwrap())
-        }));
-        try!(transfer.write_function(|data| {
-            resp.extend_from_slice(data);
-            Ok(data.len())
-        }));
-        try!(transfer.perform());
-    }
-    let code = try!(handle.response_code());
-    if code != 200 {
-        return Err(Error::HttpStatus(code));
-    }
+    try!(std::io::copy(&mut response, &mut resp));
     Ok(resp)
+
 }
 
 


### PR DESCRIPTION
Because curl seems to be very finicky to get compiling on windows for me
Note that this breaks the api a little by adding `Error::IO`, and changing `Error::Curl(curl::Error)` to `Error::Hyper(hyper::Error)`, and changing  `Error::HttpStatus(u32)` to `Error::HttpStatus(hyper::status::StatusCode)` (the last one is as there doesn't seem to be any clean way to get an integer statuscode from a hyper statuscode)
