### PR TITLE
set Content-Type to application/x-www-form-urlencoded on POST requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,8 @@ use crypto::mac::{Mac, MacResult};
 use crypto::sha1::Sha1;
 use rand::Rng;
 use reqwest::{Client, RequestBuilder, StatusCode};
-use reqwest::header::{Authorization, Headers};
+use reqwest::header::{Authorization, ContentType, Headers};
+use reqwest::mime::{Mime, SubLevel, TopLevel};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{self, Read};
@@ -300,6 +301,7 @@ pub fn post(uri: &str,
 
     let mut headers = Headers::new();
     headers.set(Authorization(header));
+    headers.set(ContentType(Mime(TopLevel::Application, SubLevel::WwwFormUrlEncoded, vec![])));
 
     let req = Client::new()?
         .post(uri)


### PR DESCRIPTION
Fixes #22.

This matches the behavior from libcurl: https://docs.rs/curl/0.4.6/curl/easy/struct.Easy.html#method.post

If we do not set this header, then POST requests to the twitter API fail with 'Unauthorized'.